### PR TITLE
Update CMakeList, bump WayWise

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,9 @@ add_executable(ControlTower
     WayWise/userinterface/map/routeplannermodule.h
     WayWise/userinterface/map/tracemodule.cpp
     WayWise/userinterface/map/tracemodule.h
+    WayWise/userinterface/vehicleparameterui.h
+    WayWise/userinterface/vehicleparameterui.cpp
+    WayWise/userinterface/vehicleparameterui.ui
     WayWise/communication/vehicleconnections/mavsdkstation.h
     WayWise/communication/vehicleconnections/mavsdkstation.cpp
     WayWise/communication/vehicleconnections/vehicleconnection.h


### PR DESCRIPTION
Parameters: get & set parameters via MAVLINK, UI support

Seems to be a bug with the custom parameters: https://github.com/mavlink/MAVSDK/issues/1805
Int and Float parameters work as they should.