### PR TITLE
Better handling of which vehicle to point to on new connection or disconnect

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -94,15 +94,14 @@ MainWindow::~MainWindow()
 void MainWindow::updateVehicleIdComboBox()
 {
     // Keep ui in sync with vehicleconnections maintained by MavsdkStation
-    // TODO: better handling of which vehicle to point to on new connection or disconnect
-    int previousCurrentIndex = ui->vehicleIdCombo->currentIndex() < 0 ? 0 : ui->vehicleIdCombo->currentIndex();
+    auto currentVehicleId = QString(ui->vehicleIdCombo->currentText()).isEmpty() ? 0 : ui->vehicleIdCombo->currentText();
 
     ui->vehicleIdCombo->clear();
     for (const auto& vehicleConnection : mMavsdkStation->getVehicleConnectionList())
         ui->vehicleIdCombo->addItem(QString::number(vehicleConnection->getVehicleState()->getId()),
                                     QVariant::fromValue(vehicleConnection));
 
-    ui->vehicleIdCombo->setCurrentIndex((previousCurrentIndex < ui->vehicleIdCombo->count()) ? previousCurrentIndex : (ui->vehicleIdCombo->count()-1));
+    ui->vehicleIdCombo->setCurrentIndex(ui->vehicleIdCombo->findText(currentVehicleId) < 0 ? 0 : ui->vehicleIdCombo->findText(currentVehicleId));
 }
 
 void MainWindow::updateUiForCurrentVehicleIdComboBoxIndex(int index) {


### PR DESCRIPTION
- **What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Fix

- **What is the current behavior? (You can also link to an open issue here)**
If a vehicle with id 2 is driven manually and a second vehicle with id 1 connects, you loose control over the driven vehicle because  the active vehicle id is updated to id 1

- **What is the new behavior (if this is a feature change)?**
Active vehicle id is kept when another vehicle connects

- **Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)**
- No

- **Other information:**
![Screenshot from 2024-08-21 12-49-38](https://github.com/user-attachments/assets/73fa1795-8b05-429e-bdd2-75ba60ffebb1)
